### PR TITLE
Fix bug for Postbuild commands

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -74,7 +74,7 @@ project "Hazel"
 		{
 		    -- "copy default.config bin\\project.config"
 			-- copy freom relative path to ... 注意这里的COPY前面没有%
-		    ("{COPY} %{cfg.buildtarget.relpath} ../bin/" ..outputdir.."\\Sandbox")
+		    ("{COPY} %{cfg.buildtarget.relpath} \"../bin/" ..outputdir.."/Sandbox/\"")
 		}
 
     filter { "configurations:Debug" }


### PR DESCRIPTION
This engine build fails first time. this solution will ensure that the command know the second arg is a folder.